### PR TITLE
Add maximum number of retries during connection.

### DIFF
--- a/sse/event_source.go
+++ b/sse/event_source.go
@@ -62,7 +62,11 @@ type Config struct {
 }
 
 func (c *Config) Connect() (*EventSource, error) {
-	source := createEventSource(c.Client, c.RetryParams, c.RequestCreator)
+	client := c.Client
+	if client == nil {
+		client = http.DefaultClient
+	}
+	source := createEventSource(client, c.RetryParams, c.RequestCreator)
 
 	readCloser, err := source.establishConnection()
 	if err != nil {

--- a/sse/event_source_test.go
+++ b/sse/event_source_test.go
@@ -460,7 +460,6 @@ var _ = Describe("EventSource", func() {
 			It("retries for specified max retries and returns an error", func() {
 				actualRetries := uint16(0)
 				config := Config{
-					Client:      http.DefaultClient,
 					RetryParams: retryParams,
 					RequestCreator: func() *http.Request {
 						request, err := http.NewRequest("GET", "http://something.non.existent", nil)

--- a/sse/event_source_test.go
+++ b/sse/event_source_test.go
@@ -459,16 +459,17 @@ var _ = Describe("EventSource", func() {
 		Context("when event source is unavailable during initial connection", func() {
 			It("retries for specified max retries and returns an error", func() {
 				actualRetries := uint16(0)
-				src, err := ConnectWithParams(
-					http.DefaultClient,
-					retryParams,
-					func() *http.Request {
+				config := Config{
+					Client:      http.DefaultClient,
+					RetryParams: retryParams,
+					RequestCreator: func() *http.Request {
 						request, err := http.NewRequest("GET", "http://something.non.existent", nil)
 						Ω(err).ShouldNot(HaveOccurred())
 						actualRetries++
 						return request
 					},
-				)
+				}
+				src, err := config.Connect()
 				Ω(err).To(HaveOccurred())
 				Ω(src).To(BeNil())
 				Ω(actualRetries).To(Equal(retryParams.MaxRetries + 1))
@@ -540,16 +541,18 @@ var _ = Describe("EventSource", func() {
 
 				It("retries for specified max retries and returns an error", func() {
 					actualRetries := uint16(0)
-					src, err := ConnectWithParams(
-						http.DefaultClient,
-						retryParams,
-						func() *http.Request {
+					config := Config{
+						Client:      http.DefaultClient,
+						RetryParams: retryParams,
+						RequestCreator: func() *http.Request {
 							request, err := http.NewRequest("GET", localServer.URL(), nil)
 							Ω(err).ShouldNot(HaveOccurred())
 							actualRetries++
 							return request
 						},
-					)
+					}
+					src, err := config.Connect()
+
 					Ω(err).NotTo(HaveOccurred())
 					Ω(src).NotTo(BeNil())
 					_, err = src.Next()
@@ -619,16 +622,18 @@ var _ = Describe("EventSource", func() {
 
 				It("returns event", func() {
 					actualRetries := uint16(0)
-					src, err := ConnectWithParams(
-						http.DefaultClient,
-						retryParams,
-						func() *http.Request {
+					config := Config{
+						Client:      http.DefaultClient,
+						RetryParams: retryParams,
+						RequestCreator: func() *http.Request {
 							request, err := http.NewRequest("GET", server.URL(), nil)
 							Ω(err).ShouldNot(HaveOccurred())
 							actualRetries++
 							return request
 						},
-					)
+					}
+					src, err := config.Connect()
+
 					Ω(err).NotTo(HaveOccurred())
 					Ω(src).NotTo(BeNil())
 					Ω(src.Next()).Should(Equal(Event{


### PR DESCRIPTION
This PR adds ability to go-sse to specify max number of retries when trying to establish connection and a network error occurs. This is to address the use case where the source is unavailable. Existing behavior is to try indefinitely thereby resulting in a hung call. This PR allows the caller of `Connect` or `Next` to get control back when the source is unavailable after retrying certain number of times. 

New `ConnectWithParams` method was added to get `EventSource` by specifying max retries. Existing `Connect` was retained as is and would default to indefinite retries.

Pivotal tracker story: [#109774972]

Regards,
@atulkc and @fordaz (CF Routing team)
